### PR TITLE
Add '-grepable' option to make output easier to grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The format of the output is simple and can be easily parsed by an external scrip
 arg [arg #]: [value] (type=[Windows type name], size=[size of arg])
 and return to module id:[module unique id], offset:[offset in memory]
 ```
+Parsing with `grep` can be done when the `-grepable` argument is used; this prints the function names and arguments all on one line:
+```
+~~4824~~ KERNELBASE.dll!CreateFileW {0: C:\Windows\Fonts\staticcache.dat (type=wchar_t*, size=0x0)} {1: 0x80000000 (type=DWORD, size=0x4)} {2: 0x3 (type=DWORD, size=0x4)} {3: 0x005cde8c (type=<unknown>*, size=0x0)} {4: 0x3 (type=DWORD, size=0x4)} {5: 0x80 (type=DWORD, size=0x4)}
+```
 The module unique identifiers table is printed at the end of the log file:
 ```
 Module Table: version 3, count 70
@@ -105,6 +109,7 @@ However, application of DBI for malware analysis is undeservedly limited by unpa
  -version             [ false]  Print version number.
  -verbose             [     1]  Change verbosity.
  -use_config          [  true]  Use config file
+ -grepable            [ false]  Grepable output
  ```
 # Configuration file syntax
 Drltrace supports external configuration files where a user can describe how drltrace should print arguments for certain API calls.

--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -96,7 +96,7 @@ print_arg(void *drcontext, drltrace_arg_t *arg)
 {
     if (arg->pre && (TEST(DRSYS_PARAM_OUT, arg->mode) && !TEST(DRSYS_PARAM_IN, arg->mode)))
         return;
-    dr_fprintf(outf, "\n    arg %d: ", arg->ordinal);
+    dr_fprintf(outf, "%s%d: ", (op_grepable.get_value() ? " {" : "\n    arg "), arg->ordinal);
     switch (arg->type) {
     case DRSYS_TYPE_VOID:         print_simple_value(arg, true); break;
     case DRSYS_TYPE_POINTER:      print_simple_value(arg, true); break;
@@ -135,6 +135,9 @@ print_arg(void *drcontext, drltrace_arg_t *arg)
               (arg->type_name == NULL ||
               TESTANY(DRSYS_PARAM_INLINED|DRSYS_PARAM_RETVAL, arg->mode)) ? "" : "*",
               arg->size);
+
+    if (op_grepable.get_value())
+        dr_fprintf(outf, "}");
 }
 
 static bool
@@ -156,10 +159,18 @@ print_args_unknown_call(app_pc func, void *wrapcxt)
 {
     uint i;
     void *drcontext = drwrap_get_drcontext(wrapcxt);
+    char *prefix = "\n    arg ";
+    char *suffix = "";
+    if (op_grepable.get_value()) {
+      prefix = " {";
+      suffix = "}";
+    }
     DR_TRY_EXCEPT(drcontext, {
         for (i = 0; i < op_unknown_args.get_value(); i++) {
-            dr_fprintf(outf, "\n    arg %d: " PFX, i,
+            dr_fprintf(outf, "%s%d: " PFX, prefix, i,
                        drwrap_get_arg(wrapcxt, i));
+            if (*suffix != '\0')
+                dr_fprintf(outf, suffix);
         }
     }, {
         dr_fprintf(outf, "<invalid memory>");

--- a/drltrace_src/drltrace_options.cpp
+++ b/drltrace_src/drltrace_options.cpp
@@ -104,3 +104,6 @@ droption_t<std::string> op_ltracelib_ops
  "", "(For internal use: sweeps up drltracelib options)",
  "This is an internal option that sweeps up other options to pass to the drltracelib.");
 
+droption_t<bool> op_grepable
+(DROPTION_SCOPE_CLIENT, "grepable", false, "Grepable output",
+ "Outputs function names and arguments entirely on one line to enable easy log grepping.");

--- a/drltrace_src/drltrace_options.h
+++ b/drltrace_src/drltrace_options.h
@@ -47,3 +47,4 @@ extern droption_t<bool> op_version;
 extern droption_t<unsigned int> op_verbose;
 extern droption_t<bool> op_use_config;
 extern droption_t<std::string> op_ltracelib_ops;
+extern droption_t<bool> op_grepable;


### PR DESCRIPTION
The default format isn't easy to grep through.  Functions are split up on multiple lines like this:

```
~~3636~~ KERNELBASE.dll!CreateFileW
    arg 0: C:\Windows\Fonts\staticcache.dat (type=wchar_t*, size=0x0)
    arg 1: 0x80000000 (type=DWORD, size=0x4)
    arg 2: 0x5 (type=DWORD, size=0x4)
    arg 3: <null> (type=<unknown>*, size=0x0)
    arg 4: 0x3 (type=DWORD, size=0x4)
    arg 5: 0x0 (type=DWORD, size=0x4)
```

Notice that if the user wants to find all calls to `CreateFileW` with `C:\Windows\` included, grep simply won't work.  With this new `-grepable` option, however, the function and arguments are outputted on the same line like this:

```
~~4824~~ KERNELBASE.dll!CreateFileW {0: C:\Windows\Fonts\staticcache.dat (type=wchar_t*, size=0x0)} {1: 0x80000000 (type=DWORD, size=0x4)} {2: 0x3 (type=DWORD, size=0x4)} {3: 0x005cde8c (type=<unknown>*, size=0x0)} {4: 0x3 (type=DWORD, size=0x4)} {5: 0x80 (type=DWORD, size=0x4)}
```

Now the user can do `grep CreateFileW logfile.log | grep C:\\Windows`