### PR TITLE
Function name filtering by wildcard, and module-level filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ However, application of DBI for malware analysis is undeservedly limited by unpa
  -config              [    ""]  The path to custom config file.
  -filter              [filter.config]  The path of the whitelist/blacklist file.
  -ignore_underscore   [ false]  Ignores library routine names starting with "_".
- -only_to_lib         [    ""]  Only reports calls to the library <lib_name>.
  -help                [ false]  Print this message.
  -version             [ false]  Print version number.
  -verbose             [     1]  Change verbosity.

--- a/drltrace_src/drltrace_options.cpp
+++ b/drltrace_src/drltrace_options.cpp
@@ -85,10 +85,6 @@ droption_t<bool> op_ignore_underscore
 (DROPTION_SCOPE_CLIENT, "ignore_underscore", false, "Ignores library routine names "
  "starting with \"_\".", "Ignores library routine names starting with \"_\".");
 
-droption_t<std::string> op_only_to_lib
-(DROPTION_SCOPE_CLIENT, "only_to_lib", "", "Only reports calls to the library <lib_name>. ",
- "Only reports calls to the library <lib_name>. Argument is case insensitive on Windows.");
-
 droption_t<bool> op_help
 (DROPTION_SCOPE_FRONTEND, "help", false, "Print this message.", "Print this message");
 

--- a/drltrace_src/drltrace_utils.cpp
+++ b/drltrace_src/drltrace_utils.cpp
@@ -48,21 +48,6 @@ int reported_disk_error;
 uint op_ignore_asserts = false;
 
 
-/* A faster(?) version of strcmp(), since strcmp() does extra string
- * comparison we don't need (we just need an equality test).  Returns
- * 0 when strings are equal, otherwise returns non-zero. */
-int
-fast_strcmp(char *s1, size_t s1_len, char *s2, size_t s2_len) {
-  if (s1_len != s2_len)
-    return -1;
-
-#ifdef WINDOWS
-  return memcmp(s1, s2, s1_len); /* VC2013 doesn't have bcmp(), sadly. */
-#else
-  return bcmp(s1, s2, s1_len);  /* Fastest option. */
-#endif
-}
-
 void
 print_prefix_to_buffer(char *buf, size_t bufsz, size_t *sofar)
 {

--- a/drltrace_src/drltrace_utils.h
+++ b/drltrace_src/drltrace_utils.h
@@ -39,7 +39,22 @@
 
 void print_prefix_to_console(void);
 
-int fast_strcmp(char *s1, size_t s1_len, char *s2, size_t s2_len);
+/* A faster(?) version of strcmp(), since strcmp() does extra string
+ * comparison we don't need (we just need an equality test).  Returns
+ * 0 when strings are equal, otherwise returns non-zero. */
+inline int
+fast_strcmp(char *s1, size_t s1_len, char *s2, size_t s2_len) {
+  if (s1_len != s2_len)
+    return -1;
+
+#ifdef WINDOWS
+  return memcmp(s1, s2, s1_len); /* VC2013 doesn't have bcmp(), sadly. */
+#else
+  return bcmp(s1, s2, s1_len);  /* Fastest option. */
+#endif
+}
+
+#define MIN(x,y) (((x) > (y)) ? (y) : (x))
 
 #ifdef DEBUG
 # define IF_DEBUG(x) x

--- a/drltrace_src/filter.config
+++ b/drltrace_src/filter.config
@@ -1,7 +1,7 @@
 #
 # This file contains module/functions to either filter in with a whitelist,
-# or filter out with a blacklist.  The module/function names are separated
-# by '!', like so:
+# or filter out with a blacklist.  They can be individually specified by
+# module name and function name, separated with '!', like so:
 #
 #   ld-linux-x86-64.so.2!malloc
 #   libc.so.6!free
@@ -9,15 +9,37 @@
 #   KERNELBASE.dll!GetLastError
 #   ... etc ...
 #
+# Furthermore, an entire module's functions can be filtered simply by
+# writing its name without any function name appended.  For example, putting
+# 'KERNEL32.dll' on a line on its own will match all functions defined in
+# KERNEL32.dll (note that it is case-sensitive).
+#
+# Lastly, a collection of functions can be filtered if the star wildcard is
+# appended.  For example, 'ntdll.dll!Rtl*' will match all functions from
+# ntdll.dll that begin with 'Rtl', including 'RtlEnterCriticalSection',
+# 'RtlLeaveCriticalSection', and many, many others.  Note that the star
+# _MUST_ appear at the end only!  In other words, only function name prefixes
+# are supported; specifying 'mod!prefix*suffix' is not supported.
+#
+# Note that module-level filtering is more efficient (in terms of speed) than
+# filtering by function names.
+#
+
 
 # Add whitelisted module/functions here.  If any entries here are found, then
 # *all* blacklist entries are ignored.
 [whitelist]
+#libc.so.6
+#ld-linux-x86-64.so.2
+
+#KERNEL32.dll
+#USER32.dll
 
 
 # Add blacklisted module/functions here.  Note that these are ignored if *any*
 # whitelist entries are given above.
 [blacklist]
+#ld-linux-x86-64.so.2!_*
 #ld-linux-x86-64.so.2!__libc_memalign
 #ld-linux-x86-64.so.2!_dl_debug_state
 #ld-linux-x86-64.so.2!calloc
@@ -36,6 +58,7 @@
 #libc.so.6!strlen
 #libc.so.6!strstr
 
+#ntdll.dll!Rtl*
 #ntdll.dll!bsearch
 #ntdll.dll!memcmp
 #ntdll.dll!memcpy


### PR DESCRIPTION
This patch allows function names to be filtered with a wildcard.  For example, all the *Rtl* functions from *ntdll.dll* can be ignored by putting in the blacklist block: `ntdll.dll!Rtl*`.

Furthermore, all of a module's functions can be filtered at once by specifying the module's name on its own.  For example, to only log calls to *kernel32.dll*, place `KERNEL32.dll` on a line on its own in the whitelist block.  (This feature obsoletes the `-only_to_lib` feature, hence it is removed.)