### PR TITLE
Change the way of printing logs:

### DIFF
--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -2,47 +2,51 @@
  * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
- /*
-  * Redistribution and use in source and binary forms, with or without
-  * modification, are permitted provided that the following conditions are met:
-  *
-  * * Redistributions of source code must retain the above copyright notice,
-  *   this list of conditions and the following disclaimer.
-  *
-  * * Redistributions in binary form must reproduce the above copyright notice,
-  *   this list of conditions and the following disclaimer in the documentation
-  *   and/or other materials provided with the distribution.
-  *
-  * * Neither the name of Google, Inc. nor the names of its contributors may be
-  *   used to endorse or promote products derived from this software without
-  *   specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-  * DAMAGE.
-  */
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
 
-  /* Library Tracing Tool: drltrace
-   *
-   * Records calls to exported library routines.
-   *
-   * The runtime options for this client are specified in drltrace_options.h,
-   * see DROPTION_SCOPE_CLIENT options.
-   */
+/* Library Tracing Tool: drltrace
+ *
+ * Records calls to exported library routines.
+ *
+ * The runtime options for this client are specified in drltrace_options.h,
+ * see DROPTION_SCOPE_CLIENT options.
+ */
 #include <fstream>
 #include <vector>
 #include "drltrace.h"
 #include "drltrace_utils.h"
 
-   /* Where to write the trace */
+#if _MSC_VER < 1900
+    #define snprintf _snprintf
+#endif
+
+/* Where to write the trace */
 static file_t outf;
 
 /* Avoid exe exports, as on Linux many apps have a ton of global symbols. */
@@ -51,13 +55,13 @@ static app_pc exe_start;
 static inline generic_func_t
 cast_to_func(void *p)
 {
-    return (generic_func_t)p;
+    return (generic_func_t) p;
 }
 
 struct _wblist {
-    char *func_name;
-    size_t func_name_len;
-    unsigned int is_wildcard;  /* Set to 1 when this is a wildcard, otherwise 0. */
+  char *func_name;
+  size_t func_name_len;
+  unsigned int is_wildcard;  /* Set to 1 when this is a wildcard, otherwise 0. */
 };
 typedef struct _wblist wb_list; /* Stands for white/black list. */
 
@@ -84,25 +88,17 @@ print_simple_value(drltrace_arg_t *arg, bool leading_zeroes, std::string &output
 {
     bool pointer = !TEST(DRSYS_PARAM_INLINED, arg->mode);
     char str[128];
-    sprintf(str, pointer ? "0x" PFX : (leading_zeroes ? "0x" PFX : PIFX), arg->value);
+    snprintf(str, 128, pointer ? PFX : (leading_zeroes ? PFX : PIFX), arg->value);
     output.append(str);
+
     if (pointer && ((arg->pre && TEST(DRSYS_PARAM_IN, arg->mode)) ||
-        (!arg->pre && TEST(DRSYS_PARAM_OUT, arg->mode)))) {
+                    (!arg->pre && TEST(DRSYS_PARAM_OUT, arg->mode)))) {
         ptr_uint_t deref = 0;
         ASSERT(arg->size <= sizeof(deref), "too-big simple type");
         /* We assume little-endian */
         if (dr_safe_read((void *)arg->value, arg->size, &deref, NULL)) {
-            char str[128];
-            if (leading_zeroes) {
-                sprintf(str, PFX, deref);
-                output.append(" => 0x");
-                output.append(str);
-            }
-            else {
-                sprintf(str, PIFX, deref);
-                output.append(" => ");
-                output.append(str);
-            }
+            snprintf(str, 128, (leading_zeroes ? " => " PFX : " => " PIFX), deref);
+            output.append(str);
         }
     }
 }
@@ -114,14 +110,11 @@ print_string(void *drcontext, void *pointer_str, bool is_wide, std::string &outp
         output.append("<null>");
     else {
         DR_TRY_EXCEPT(drcontext, {
-            // dr_fprintf(outf, is_wide ? "%S" : "%s", pointer_str);
             char str[256];
-        sprintf(str, PFX, pointer_str);
-        output.append("0x");
-        output.append(str);
-            }, {
-                output.append("<invalid memory>");
-            });
+            snprintf(str, 256, is_wide ? "%S" : "%s", pointer_str);
+        }, {
+            output.append("<invalid memory>");
+        });
     }
 }
 
@@ -133,7 +126,6 @@ print_arg(void *drcontext, drltrace_arg_t *arg, std::string &output)
     output.append(op_grepable.get_value() ? " {" : "\n    arg ");
     output.append(std::to_string(arg->ordinal));
     output.append(": ");
-
     switch (arg->type) {
     case DRSYS_TYPE_VOID:         print_simple_value(arg, true, output); break;
     case DRSYS_TYPE_POINTER:      print_simple_value(arg, true, output); break;
@@ -144,12 +136,12 @@ print_arg(void *drcontext, drltrace_arg_t *arg, std::string &output)
     case DRSYS_TYPE_HANDLE:       print_simple_value(arg, false, output); break;
     case DRSYS_TYPE_NTSTATUS:     print_simple_value(arg, false, output); break;
     case DRSYS_TYPE_ATOM:         print_simple_value(arg, false, output); break;
-        #ifdef WINDOWS
+#ifdef WINDOWS
     case DRSYS_TYPE_LCID:         print_simple_value(arg, false, output); break;
     case DRSYS_TYPE_LPARAM:       print_simple_value(arg, false, output); break;
     case DRSYS_TYPE_SIZE_T:       print_simple_value(arg, false, output); break;
     case DRSYS_TYPE_HMODULE:      print_simple_value(arg, false, output); break;
-        #endif
+#endif
     case DRSYS_TYPE_CSTRING:
         print_string(drcontext, (void *)arg->value, false, output);
         break;
@@ -161,14 +153,13 @@ print_arg(void *drcontext, drltrace_arg_t *arg, std::string &output)
             output.append("<null>");
         else {
             char str[128];
-            sprintf(str, PFX, arg->value);
-            output.append("0x");
+            snprintf(str, 128, PFX, arg->value);
             output.append(str);
         }
     }
     }
     char str[128];
-    sprintf(str, PFX, arg->size);
+    snprintf(str, 128, PFX, arg->size);
 
     output.append("(");
     output.append((arg->arg_name == NULL) ? "" : "name=");
@@ -178,7 +169,7 @@ print_arg(void *drcontext, drltrace_arg_t *arg, std::string &output)
     output.append((arg->type_name == NULL) ? "\"\"" : arg->type_name);
     output.append((arg->type_name == NULL ||
         TESTANY(DRSYS_PARAM_INLINED|DRSYS_PARAM_RETVAL, arg->mode)) ? "" : "*");
-    output.append(", size=0x");
+    output.append(", size=");
     output.append(str);
     output.append(")");
 
@@ -208,8 +199,8 @@ print_args_unknown_call(app_pc func, void *wrapcxt, std::string &output)
     char *prefix = "\n    arg ";
     char *suffix = "";
     if (op_grepable.get_value()) {
-        prefix = " {";
-        suffix = "}";
+      prefix = " {";
+      suffix = "}";
     }
     DR_TRY_EXCEPT(drcontext, {
         for (i = 0; i < op_unknown_args.get_value(); i++) {
@@ -217,16 +208,15 @@ print_args_unknown_call(app_pc func, void *wrapcxt, std::string &output)
             output.append(std::to_string(i));
             output.append(": ");
             char str[128];
-            sprintf(str, PFX, drwrap_get_arg(wrapcxt, i));
-            output.append("0x");
+            snprintf(str, 128, PFX, drwrap_get_arg(wrapcxt, i));
             output.append(str);
             if (*suffix != '\0')
                 output.append(suffix);
         }
-        }, {
-            output.append("<invalid memory>");
+    }, {
+        output.append("<invalid memory>");
         /* Just keep going */
-        });
+    });
     /* all args have been sucessfully printed */
     output.append(op_print_ret_addr.get_value() ? "\n   ": "");
 }
@@ -253,14 +243,14 @@ print_symbolic_args(const char *name, void *wrapcxt, app_pc func, std::string &o
     if (op_max_args.get_value() == 0)
         return;
 
-    if (op_use_config.get_value()) {
-        /* looking for libcall in libcalls hashtable */
-        args_vec = libcalls_search(name);
-        if (print_libcall_args(args_vec, wrapcxt, output)) {
-            output.append(op_print_ret_addr.get_value() ? "\n   " : "");
-            return; /* we found libcall and sucessfully printed all arguments */
-        }
-    }
+	if (op_use_config.get_value()) {
+		/* looking for libcall in libcalls hashtable */
+		args_vec = libcalls_search(name);
+		if (print_libcall_args(args_vec, wrapcxt, output)) {
+			output.append(op_print_ret_addr.get_value() ? "\n   " : "");
+			return; /* we found libcall and sucessfully printed all arguments */
+		}
+	}
     /* use standard type-blind scheme */
     if (op_unknown_args.get_value() > 0)
         print_args_unknown_call(func, wrapcxt, output);
@@ -273,7 +263,7 @@ print_symbolic_args(const char *name, void *wrapcxt, app_pc func, std::string &o
 static void
 lib_entry(void *wrapcxt, INOUT void **user_data)
 {
-    const char *name = (const char *)*user_data;
+    const char *name = (const char *) *user_data;
     const char *modname = NULL;
     app_pc func = drwrap_get_func(wrapcxt);
     module_data_t *mod;
@@ -289,9 +279,9 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
         app_pc retaddr =  NULL;
         DR_TRY_EXCEPT(drcontext, {
             retaddr = drwrap_get_retaddr(wrapcxt);
-            }, { /* EXCEPT */
-                retaddr = NULL;
-            });
+        }, { /* EXCEPT */
+            retaddr = NULL;
+        });
         if (retaddr != NULL) {
             mod = dr_lookup_module(retaddr);
             if (mod != NULL) {
@@ -300,8 +290,7 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
                 if (!from_exe)
                     return;
             }
-        }
-        else {
+        } else {
             /* Nearly all of these cases should be things like KiUserCallbackDispatcher
              * or other abnormal transitions.
              * If the user really wants to see everything they can not pass
@@ -324,9 +313,9 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
 
     /* Temporary workaround for VC2013, which doesn't have snprintf().
      * apparently, this was added in later releases... */
-    #ifdef WINDOWS
-    #define snprintf _snprintf
-    #endif
+#ifdef WINDOWS
+#define snprintf _snprintf
+#endif
     unsigned int module_name_len = (unsigned int)snprintf(module_name, \
         sizeof(module_name) - 1, "%s%s%s", modname == NULL ? "" : modname, \
         modname == NULL ? "" : "!", name);
@@ -335,51 +324,51 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
     bool allowed = false;
     bool tested = false;  /* True only if any white/blacklist testing below is done. */
     for (unsigned int i = 0; (allowed == false) && (i < filter_function_whitelist_len); i++) {
-        tested = true;
+      tested = true;
 
-        /* If the whitelist entry contains a wildcard, then compare only the shortest
-         * part of either string. */
-        unsigned int module_name_len_compare;
-        if (filter_function_whitelist[i].is_wildcard)
-            module_name_len_compare = MIN(module_name_len, \
-                filter_function_whitelist[i].func_name_len);
-        else
-            module_name_len_compare = module_name_len;
+      /* If the whitelist entry contains a wildcard, then compare only the shortest
+       * part of either string. */
+      unsigned int module_name_len_compare;
+      if (filter_function_whitelist[i].is_wildcard)
+        module_name_len_compare = MIN(module_name_len, \
+          filter_function_whitelist[i].func_name_len);
+      else
+        module_name_len_compare = module_name_len;
 
-        if (fast_strcmp(module_name, module_name_len_compare, \
-            filter_function_whitelist[i].func_name, \
-            filter_function_whitelist[i].func_name_len) == 0) {
-            allowed = true;
-        }
+      if (fast_strcmp(module_name, module_name_len_compare, \
+          filter_function_whitelist[i].func_name, \
+          filter_function_whitelist[i].func_name_len) == 0) {
+        allowed = true;
+      }
     }
 
     /* Check the blacklist if it was specified instead of a whitelist. */
     if (!allowed && filter_function_blacklist_len > 0) {
-        allowed = true;
-        for (unsigned int i = 0; allowed && (i < filter_function_blacklist_len); i++) {
-            tested = true;
+      allowed = true;
+      for (unsigned int i = 0; allowed && (i < filter_function_blacklist_len); i++) {
+        tested = true;
 
-            /* If the blacklist entry contains a wildcard, then compare only the shortest
-             * part of either string. */
-            unsigned int module_name_len_compare;
-            if (filter_function_blacklist[i].is_wildcard)
-                module_name_len_compare = MIN(module_name_len, \
-                    filter_function_blacklist[i].func_name_len);
-            else
-                module_name_len_compare = module_name_len;
+	/* If the blacklist entry contains a wildcard, then compare only the shortest
+	 * part of either string. */
+        unsigned int module_name_len_compare;
+        if (filter_function_blacklist[i].is_wildcard)
+          module_name_len_compare = MIN(module_name_len, \
+            filter_function_blacklist[i].func_name_len);
+        else
+          module_name_len_compare = module_name_len;
 
-            if (fast_strcmp(module_name, module_name_len_compare, \
-                filter_function_blacklist[i].func_name, \
-                filter_function_blacklist[i].func_name_len) == 0) {
-                allowed = false;
-            }
+        if (fast_strcmp(module_name, module_name_len_compare, \
+            filter_function_blacklist[i].func_name, \
+            filter_function_blacklist[i].func_name_len) == 0) {
+          allowed = false;
         }
+      }
     }
 
     /* If whitelist/blacklist testing was performed, and it was determined
      * this function is not to be logged... */
     if (tested && !allowed)
-        return;
+      return;
 
     std::string output = "";
 
@@ -391,14 +380,13 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
     }
     else
         output.append("~~Dr.L~~ ");
-
     output.append(module_name);
 
     /* XXX: We employ two schemes of arguments printing.  We are looking for prototypes
      * in config file specified by user to get symbolic representation of arguments
      * for known library calls. For the rest of library calls.  If there is no info
      * we employ type-blindprinting and use -num_unknown_args to get a count of arguments
-   * to print.
+	 * to print.
      */
     print_symbolic_args(name, wrapcxt, func, output);
 
@@ -416,13 +404,14 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
             }
         }
     }
-
     output.append("\n");
+
     char * output_array;
     output_array = (char*)calloc(output.length() + 1, sizeof(char));
     strcpy(output_array, output.c_str());
     dr_fprintf(outf, output_array);
     free(output_array);
+    
     if (mod != NULL)
         dr_free_module_data(mod);
 }
@@ -437,31 +426,30 @@ iterate_exports(const module_data_t *info, bool add)
         app_pc func = NULL;
         if (sym->is_code)
             func = sym->addr;
-        #ifdef LINUX
+#ifdef LINUX
         else if (sym->is_indirect_code) {
             /* Invoke the export to get the real entry: */
-            app_pc(*indir)(void) = (app_pc(*)(void)) cast_to_func(sym->addr);
+            app_pc (*indir)(void) = (app_pc (*)(void)) cast_to_func(sym->addr);
             void *drcontext = dr_get_current_drcontext();
             DR_TRY_EXCEPT(drcontext, {
                 func = (*indir)();
-                }, { /* EXCEPT */
-                    func = NULL;
-                });
+            }, { /* EXCEPT */
+                func = NULL;
+            });
             VNOTIFY(2, "export %s indirected from " PFX " to " PFX NL,
-                sym->name, sym->addr, func);
+                   sym->name, sym->addr, func);
         }
-        #endif
+#endif
         if (op_ignore_underscore.get_value() && strstr(sym->name, "_") == sym->name)
             func = NULL;
         if (func != NULL) {
             if (add) {
                 IF_DEBUG(bool ok =)
-                    drwrap_wrap_ex(func, lib_entry, NULL, (void *)sym->name, 0);
+                    drwrap_wrap_ex(func, lib_entry, NULL, (void *) sym->name, 0);
                 ASSERT(ok, "wrap request failed");
                 VNOTIFY(2, "wrapping export %s!%s @" PFX NL,
-                    dr_module_preferred_name(info), sym->name, func);
-            }
-            else {
+                       dr_module_preferred_name(info), sym->name, func);
+            } else {
                 IF_DEBUG(bool ok =)
                     drwrap_unwrap(func, lib_entry, NULL);
                 ASSERT(ok, "unwrap request failed");
@@ -474,37 +462,35 @@ iterate_exports(const module_data_t *info, bool add)
 static bool
 library_matches_filter(const module_data_t *info)
 {
-    if (!filter_module_whitelist.empty()) {
-        const char *libname = dr_module_preferred_name(info);
-        if (libname == NULL)
-            return false;
+  if (!filter_module_whitelist.empty()) {
+    const char *libname = dr_module_preferred_name(info);
+    if (libname == NULL)
+      return false;
 
-        for (std::vector<std::string>::const_iterator iter = \
-            filter_module_whitelist.begin(); iter != filter_module_whitelist.end(); \
-            iter++) {
+    for (std::vector<std::string>::const_iterator iter = \
+        filter_module_whitelist.begin(); iter != filter_module_whitelist.end(); \
+        iter++) {
 
-            if (strcmp(libname, iter->c_str()) == 0)
-                return true;
-        }
-
-        return false;
+      if (strcmp(libname, iter->c_str()) == 0)
+	return true;
     }
-    else if (!filter_module_blacklist.empty()) {
-        const char *libname = dr_module_preferred_name(info);
-        if (libname == NULL)
-            return true;
 
-        for (std::vector<std::string>::const_iterator iter = \
-            filter_module_blacklist.begin(); iter != filter_module_blacklist.end(); \
-            iter++) {
-            if (strcmp(libname, iter->c_str()) == 0)
-                return false;
-        }
+    return false;
+  } else if (!filter_module_blacklist.empty()) {
+    const char *libname = dr_module_preferred_name(info);
+    if (libname == NULL)
+      return true;
 
-        return true;
+    for (std::vector<std::string>::const_iterator iter = \
+        filter_module_blacklist.begin(); iter != filter_module_blacklist.end(); \
+        iter++) {
+      if (strcmp(libname, iter->c_str()) == 0)
+	return false;
     }
-    else
-        return true;
+
+    return true;
+  } else
+    return true;
 }
 
 static void
@@ -533,13 +519,13 @@ open_log_file(void)
         outf = STDERR;
     else {
         outf = drx_open_unique_appid_file(op_logdir.get_value().c_str(),
-            dr_get_process_id(),
-            "drltrace", "log",
-            #ifndef WINDOWS
-            DR_FILE_CLOSE_ON_FORK |
-            #endif
-            DR_FILE_ALLOW_LARGE,
-            buf, BUFFER_SIZE_ELEMENTS(buf));
+                                          dr_get_process_id(),
+                                          "drltrace", "log",
+#ifndef WINDOWS
+                                          DR_FILE_CLOSE_ON_FORK |
+#endif
+                                          DR_FILE_ALLOW_LARGE,
+                                          buf, BUFFER_SIZE_ELEMENTS(buf));
         ASSERT(outf != INVALID_FILE, "failed to open log file");
         VNOTIFY(0, "drltrace log file is %s" NL, buf);
 
@@ -549,33 +535,33 @@ open_log_file(void)
 /* Frees a wblist array. */
 static void
 free_wblist_array(wb_list **wbl, unsigned int wb_list_len) {
-    if ((wbl == NULL) || (*wbl == NULL) || (wb_list_len == 0))
-        return;
+  if ((wbl == NULL) || (*wbl == NULL) || (wb_list_len == 0))
+    return;
 
-    /* Loop through all entries and free the function name, since it was
-     * created with strdup().  Set it (and the length) to zero for good
-     * measure. */
-    for (unsigned int i = 0; i < wb_list_len; i++) {
-        wb_list *l = *wbl;
-        free(l[i].func_name);  l[i].func_name = NULL;
-        l[i].func_name_len = 0;
-    }
+  /* Loop through all entries and free the function name, since it was
+   * created with strdup().  Set it (and the length) to zero for good
+   * measure. */
+  for (unsigned int i = 0; i < wb_list_len; i++) {
+    wb_list *l = *wbl;
+    free(l[i].func_name);  l[i].func_name = NULL;
+    l[i].func_name_len = 0;
+  }
 
-    /* Now free the array itself. */
-    free(*wbl);  *wbl = NULL;
+  /* Now free the array itself. */
+  free(*wbl);  *wbl = NULL;
 }
 
 /* Adds a module name to the module filter. */
 void
 add_module_filter(std::vector<std::string> &module_wbl, const char *module_name) {
 
-    /* If the module name is already in the filter, ignore. */
-    for (std::vector<std::string>::const_iterator iter = module_wbl.begin(); iter != module_wbl.end(); iter++) {
-        if (strcmp(module_name, iter->c_str()) == 0)
-            return;
-    }
+  /* If the module name is already in the filter, ignore. */
+  for (std::vector<std::string>::const_iterator iter = module_wbl.begin(); iter != module_wbl.end(); iter++) {
+    if (strcmp(module_name, iter->c_str()) == 0)
+      return;
+  }
 
-    module_wbl.push_back(module_name);
+  module_wbl.push_back(module_name);
 }
 
 /* Convert a vector to an array of wb_list structs.  This may be faster
@@ -583,127 +569,125 @@ add_module_filter(std::vector<std::string> &module_wbl, const char *module_name)
 static void
 parse_filter(std::vector<std::string> &v_in, bool is_whitelist, std::vector<std::string> &module_wbl, wb_list **func_wbl, unsigned int *func_wbl_len) {
 
-    /* First look for entries that don't have a '!'; these are module names that
-     * need to be filtered at the module-level. */
-    for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
-        iter != v_in.end(); iter++) {
-        if (iter->find('!') == std::string::npos)
-            add_module_filter(module_wbl, iter->c_str());
+  /* First look for entries that don't have a '!'; these are module names that
+   * need to be filtered at the module-level. */
+  for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
+       iter != v_in.end(); iter++) {
+    if (iter->find('!') == std::string::npos)
+      add_module_filter(module_wbl, iter->c_str());
+  }
+
+  /* Allocate the array of wb_list structs. */
+  unsigned int v_in_len = v_in.size();
+  *func_wbl = (wb_list *)calloc(v_in_len, sizeof(wb_list));
+  if (*func_wbl == NULL) {
+    fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
+    exit(-1);
+  }
+
+  /* For every entry in the vector, strdup() the function name and add
+   * it to the array. */
+  unsigned j = 0;
+  for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
+       (iter != v_in.end()) && (j < v_in_len); iter++, j++) {
+
+    unsigned int is_wildcard = 0;
+    char *s = strdup(iter->c_str());
+    if (s == NULL) {
+      fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
+      exit(-1);
     }
 
-    /* Allocate the array of wb_list structs. */
-    unsigned int v_in_len = v_in.size();
-    *func_wbl = (wb_list *)calloc(v_in_len, sizeof(wb_list));
-    if (*func_wbl == NULL) {
-        fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
-        exit(-1);
+    /* If the function name ends with a '*', then it is a wildcard prefix.  Set the
+     * wildcard flag and cut off the trailing '*'. */
+    if (s[strlen(s) - 1] == '*') {
+      s[strlen(s) - 1] = '\0';
+      is_wildcard = 1;
+
+    /* If a module name was provided without a corresponding function, then this is a
+     * wildcard module.  These, too, must be added to the function-level filter in
+     * order for whitelisted functions to be allowed through. */
+    } else if (strchr(s, '!') == NULL)
+      is_wildcard = 1;
+
+    /* If we're parsing the whitelist filter, ensure that the module for this function
+     * is in the module whitelist as well, otherwise the function-level filtering will
+     * never trigger. */
+    if (is_whitelist) {
+      char *module_name = strdup(s);
+      char *bang_pos = strchr(module_name, '!');
+      if (bang_pos != NULL) {
+	*bang_pos = '\0';
+	add_module_filter(module_wbl, module_name);
+      }
+      free(module_name);  module_name = NULL;
     }
 
-    /* For every entry in the vector, strdup() the function name and add
-     * it to the array. */
-    unsigned j = 0;
-    for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
-        (iter != v_in.end()) && (j < v_in_len); iter++, j++) {
+    wb_list *l = *func_wbl;
+    l[j].func_name = s;
+    l[j].is_wildcard = is_wildcard;
 
-        unsigned int is_wildcard = 0;
-        char *s = strdup(iter->c_str());
-        if (s == NULL) {
-            fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
-            exit(-1);
-        }
+    /* We store the function name length too, so we don't repeatedly
+     * call strlen() on an unchanging string in the critical region. */
+    l[j].func_name_len = strlen(s);
+  }
 
-        /* If the function name ends with a '*', then it is a wildcard prefix.  Set the
-         * wildcard flag and cut off the trailing '*'. */
-        if (s[strlen(s) - 1] == '*') {
-            s[strlen(s) - 1] = '\0';
-            is_wildcard = 1;
-
-            /* If a module name was provided without a corresponding function, then this is a
-             * wildcard module.  These, too, must be added to the function-level filter in
-             * order for whitelisted functions to be allowed through. */
-        }
-        else if (strchr(s, '!') == NULL)
-            is_wildcard = 1;
-
-        /* If we're parsing the whitelist filter, ensure that the module for this function
-         * is in the module whitelist as well, otherwise the function-level filtering will
-         * never trigger. */
-        if (is_whitelist) {
-            char *module_name = strdup(s);
-            char *bang_pos = strchr(module_name, '!');
-            if (bang_pos != NULL) {
-                *bang_pos = '\0';
-                add_module_filter(module_wbl, module_name);
-            }
-            free(module_name);  module_name = NULL;
-        }
-
-        wb_list *l = *func_wbl;
-        l[j].func_name = s;
-        l[j].is_wildcard = is_wildcard;
-
-        /* We store the function name length too, so we don't repeatedly
-         * call strlen() on an unchanging string in the critical region. */
-        l[j].func_name_len = strlen(s);
-    }
-
-    *func_wbl_len = v_in_len;
+  *func_wbl_len = v_in_len;
 }
 
 /* Parse the whitelist/blacklist entries in the filter file. */
 static void
 parse_filter_file(void)
 {
-    if (op_filter_file.get_value().empty())
-        return;
+  if (op_filter_file.get_value().empty())
+    return;
 
-    std::vector<std::string> temp_whitelist;
-    std::vector<std::string> temp_blacklist;
+  std::vector<std::string> temp_whitelist;
+  std::vector<std::string> temp_blacklist;
 
-    std::ifstream filter_file(op_filter_file.get_value().c_str());
+  std::ifstream filter_file(op_filter_file.get_value().c_str());
 
-    /* Loop through every line in the filter file. */
-    std::string line;
-    bool mode_whitelist = false, mode_blacklist = false;
-    while (std::getline(filter_file, line)) {
+  /* Loop through every line in the filter file. */
+  std::string line;
+  bool mode_whitelist = false, mode_blacklist = false;
+  while (std::getline(filter_file, line)) {
 
-        /* Skip empty lines and comments. */
-        if (line.empty() || (line.find("#") == 0))
-            continue;
+    /* Skip empty lines and comments. */
+    if (line.empty() || (line.find("#") == 0))
+      continue;
 
-        /* When we find a whitelist header, add subsequent lines to the whitelist.
-        /* Otherwise, when we find a blacklist header, add subsequent lines to the
-        /* blacklist. */
-        if (line == std::string("[whitelist]")) {
-            mode_whitelist = true;
-            mode_blacklist = false;
-            continue;
-        }
-        else if (line == std::string("[blacklist]")) {
-            mode_whitelist = false;
-            mode_blacklist = true;
-            continue;
-        }
-
-        if (mode_whitelist)
-            temp_whitelist.push_back(line);
-        else if (mode_blacklist)
-            temp_blacklist.push_back(line);
+    /* When we find a whitelist header, add subsequent lines to the whitelist.
+    /* Otherwise, when we find a blacklist header, add subsequent lines to the
+    /* blacklist. */
+    if (line == std::string("[whitelist]")) {
+      mode_whitelist = true;
+      mode_blacklist = false;
+      continue;
+    } else if (line == std::string("[blacklist]")) {
+      mode_whitelist = false;
+      mode_blacklist = true;
+      continue;
     }
 
-    /* If both a whitelist and a blacklist was specified, the blacklist is
-     * ignored. */
-    if (!temp_whitelist.empty() && !temp_blacklist.empty())
-        temp_blacklist.clear();
+    if (mode_whitelist)
+      temp_whitelist.push_back(line);
+    else if (mode_blacklist)
+      temp_blacklist.push_back(line);
+  }
 
-    /* Convert the vectors to an array of wb_list structs.  This is
-     * possibly faster to process in the critical region later. */
-    if (!temp_whitelist.empty())
-        parse_filter(temp_whitelist, true, filter_module_whitelist, &filter_function_whitelist, &filter_function_whitelist_len);
-    else if (!temp_blacklist.empty())
-        parse_filter(temp_blacklist, false, filter_module_blacklist, &filter_function_blacklist, &filter_function_blacklist_len);
+  /* If both a whitelist and a blacklist was specified, the blacklist is
+   * ignored. */
+  if (!temp_whitelist.empty() && !temp_blacklist.empty())
+    temp_blacklist.clear();
 
-    filter_file.close();
+  /* Convert the vectors to an array of wb_list structs.  This is
+   * possibly faster to process in the critical region later. */
+  if (!temp_whitelist.empty())
+    parse_filter(temp_whitelist, true, filter_module_whitelist, &filter_function_whitelist, &filter_function_whitelist_len);
+  else if (!temp_blacklist.empty())
+    parse_filter(temp_blacklist, false, filter_module_blacklist, &filter_function_blacklist, &filter_function_blacklist_len);
+
+  filter_file.close();
 }
 
 #ifndef WINDOWS
@@ -743,23 +727,23 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     module_data_t *exe;
     IF_DEBUG(bool ok;)
 
-        dr_set_client_name("Dr. LTrace", "???");
+    dr_set_client_name("Dr. LTrace", "???");
 
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv,
-        NULL, NULL))
+                                       NULL, NULL))
         ASSERT(false, "unable to parse options specified for drltracelib");
 
-    IF_DEBUG(ok =)
+    IF_DEBUG(ok = )
         drmgr_init();
     ASSERT(ok, "drmgr failed to initialize");
-    IF_DEBUG(ok =)
+    IF_DEBUG(ok = )
         drwrap_init();
     ASSERT(ok, "drwrap failed to initialize");
-    IF_DEBUG(ok =)
+    IF_DEBUG(ok = )
         drx_init();
     ASSERT(ok, "drx failed to initialize");
     if (op_print_ret_addr.get_value()) {
-        IF_DEBUG(ok =)
+        IF_DEBUG(ok = )
             drmodtrack_init();
         ASSERT(ok == DRCOVLIB_SUCCESS, "drmodtrack failed to initialize");
     }
@@ -775,18 +759,18 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
      * we don't care about the app context.
      */
     drwrap_set_global_flags((drwrap_global_flags_t)
-        (DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));
+                            (DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));
 
     dr_register_exit_event(event_exit);
-    #ifdef UNIX
+#ifdef UNIX
     dr_register_fork_init_event(event_fork);
-    #endif
+#endif
     drmgr_register_module_load_event(event_module_load);
     drmgr_register_module_unload_event(event_module_unload);
 
-    #ifdef WINDOWS
+#ifdef WINDOWS
     dr_enable_console_printing();
-    #endif
+#endif
     if (op_max_args.get_value() > 0)
         parse_config();
 

--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -168,17 +168,18 @@ print_arg(void *drcontext, drltrace_arg_t *arg, std::string &output)
     }
     }
     char str[128];
-    snprintf(str, 128, "0x%x", arg->size);
-
     output.append(" (");
     output.append((arg->arg_name == NULL) ? "" : "name=");
-    output.append((arg->arg_name == NULL) ? "" : arg->arg_name);
+    snprintf(str, 128, "%s", (arg->arg_name == NULL) ? "" : arg->arg_name);
+    output.append(str);
     output.append((arg->arg_name == NULL) ? "" : ", ");
     output.append("type=");
-    output.append((arg->type_name == NULL) ? "\"\"" : arg->type_name);
+    snprintf(str, 128, "%s", (arg->type_name == NULL) ? "\"\"" : arg->type_name);
+    output.append(str);
     output.append((arg->type_name == NULL ||
         TESTANY(DRSYS_PARAM_INLINED|DRSYS_PARAM_RETVAL, arg->mode)) ? "" : "*");
     output.append(", size=");
+    snprintf(str, 128, "0x%x", arg->size);
     output.append(str);
     output.append(")");
 

--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -88,7 +88,7 @@ print_simple_value(drltrace_arg_t *arg, bool leading_zeroes, std::string &output
 {
     bool pointer = !TEST(DRSYS_PARAM_INLINED, arg->mode);
     char str[128];
-    snprintf(str, 128, pointer ? PFX : (leading_zeroes ? PFX : PIFX), arg->value);
+    snprintf(str, 128, pointer ? "0x%016x" : (leading_zeroes ? "0x%016x" : PIFX), arg->value);
     output.append(str);
 
     if (pointer && ((arg->pre && TEST(DRSYS_PARAM_IN, arg->mode)) ||
@@ -97,7 +97,7 @@ print_simple_value(drltrace_arg_t *arg, bool leading_zeroes, std::string &output
         ASSERT(arg->size <= sizeof(deref), "too-big simple type");
         /* We assume little-endian */
         if (dr_safe_read((void *)arg->value, arg->size, &deref, NULL)) {
-            snprintf(str, 128, (leading_zeroes ? " => " PFX : " => " PIFX), deref);
+            snprintf(str, 128, (leading_zeroes ? " => " "0x%016x" : " => " PIFX), deref);
             output.append(str);
         }
     }
@@ -112,6 +112,7 @@ print_string(void *drcontext, void *pointer_str, bool is_wide, std::string &outp
         DR_TRY_EXCEPT(drcontext, {
             char str[256];
             snprintf(str, 256, is_wide ? "%S" : "%s", pointer_str);
+            output.append(str, strlen(str) - 1);
         }, {
             output.append("<invalid memory>");
         });
@@ -153,15 +154,15 @@ print_arg(void *drcontext, drltrace_arg_t *arg, std::string &output)
             output.append("<null>");
         else {
             char str[128];
-            snprintf(str, 128, PFX, arg->value);
+            snprintf(str, 128, "0x%016x", arg->value);
             output.append(str);
         }
     }
     }
     char str[128];
-    snprintf(str, 128, PFX, arg->size);
+    snprintf(str, 128, "0x%x", arg->size);
 
-    output.append("(");
+    output.append(" (");
     output.append((arg->arg_name == NULL) ? "" : "name=");
     output.append((arg->arg_name == NULL) ? "" : arg->arg_name);
     output.append((arg->arg_name == NULL) ? "" : ", ");
@@ -208,7 +209,7 @@ print_args_unknown_call(app_pc func, void *wrapcxt, std::string &output)
             output.append(std::to_string(i));
             output.append(": ");
             char str[128];
-            snprintf(str, 128, PFX, drwrap_get_arg(wrapcxt, i));
+            snprintf(str, 128, "0x%016x" ,drwrap_get_arg(wrapcxt, i));
             output.append(str);
             if (*suffix != '\0')
                 output.append(suffix);
@@ -399,7 +400,7 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
                 output.append(std::to_string(mod_id));
                 output.append(", offset:");
                 char str[128];
-                sprintf(str, PIFX, ret_addr - mod_start);
+                snprintf(str, 128, PIFX, ret_addr - mod_start);
                 output.append(str);
             }
         }

--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -112,7 +112,15 @@ print_string(void *drcontext, void *pointer_str, bool is_wide, std::string &outp
         DR_TRY_EXCEPT(drcontext, {
             char str[256];
             snprintf(str, 256, is_wide ? "%S" : "%s", pointer_str);
-            output.append(str, strlen(str) - 1);
+            output.append(str, strlen(str));
+            if (output.back() == '\n')
+            {
+                output.pop_back();
+            }
+            if (output.back() == '\r')
+            {
+                output.pop_back();
+            }
         }, {
             output.append("<invalid memory>");
         });

--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -42,7 +42,7 @@
 #include "drltrace.h"
 #include "drltrace_utils.h"
 
-#if _MSC_VER < 1900
+#if WINDOWS
     #define snprintf _snprintf
 #endif
 

--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -113,14 +113,6 @@ print_string(void *drcontext, void *pointer_str, bool is_wide, std::string &outp
             char str[256];
             snprintf(str, 256, is_wide ? "%S" : "%s", pointer_str);
             output.append(str, strlen(str));
-            if (output.back() == '\n')
-            {
-                output.pop_back();
-            }
-            if (output.back() == '\r')
-            {
-                output.pop_back();
-            }
         }, {
             output.append("<invalid memory>");
         });

--- a/drltrace_src/drltrace.cpp
+++ b/drltrace_src/drltrace.cpp
@@ -2,47 +2,47 @@
  * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
-/*
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * * Redistributions of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *
- * * Neither the name of Google, Inc. nor the names of its contributors may be
- *   used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- * DAMAGE.
- */
+ /*
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice,
+  *   this list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of Google, Inc. nor the names of its contributors may be
+  *   used to endorse or promote products derived from this software without
+  *   specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+  * DAMAGE.
+  */
 
-/* Library Tracing Tool: drltrace
- *
- * Records calls to exported library routines.
- *
- * The runtime options for this client are specified in drltrace_options.h,
- * see DROPTION_SCOPE_CLIENT options.
- */
+  /* Library Tracing Tool: drltrace
+   *
+   * Records calls to exported library routines.
+   *
+   * The runtime options for this client are specified in drltrace_options.h,
+   * see DROPTION_SCOPE_CLIENT options.
+   */
 #include <fstream>
 #include <vector>
 #include "drltrace.h"
 #include "drltrace_utils.h"
 
-/* Where to write the trace */
+   /* Where to write the trace */
 static file_t outf;
 
 /* Avoid exe exports, as on Linux many apps have a ton of global symbols. */
@@ -51,13 +51,13 @@ static app_pc exe_start;
 static inline generic_func_t
 cast_to_func(void *p)
 {
-    return (generic_func_t) p;
+    return (generic_func_t)p;
 }
 
 struct _wblist {
-  char *func_name;
-  size_t func_name_len;
-  unsigned int is_wildcard;  /* Set to 1 when this is a wildcard, otherwise 0. */
+    char *func_name;
+    size_t func_name_len;
+    unsigned int is_wildcard;  /* Set to 1 when this is a wildcard, otherwise 0. */
 };
 typedef struct _wblist wb_list; /* Stands for white/black list. */
 
@@ -80,85 +80,114 @@ static std::vector<std::string> filter_module_blacklist;
  */
 
 static void
-print_simple_value(drltrace_arg_t *arg, bool leading_zeroes)
+print_simple_value(drltrace_arg_t *arg, bool leading_zeroes, std::string &output)
 {
     bool pointer = !TEST(DRSYS_PARAM_INLINED, arg->mode);
-    dr_fprintf(outf, pointer ? PFX : (leading_zeroes ? PFX : PIFX), arg->value);
+    char str[128];
+    sprintf(str, pointer ? "0x" PFX : (leading_zeroes ? "0x" PFX : PIFX), arg->value);
+    output.append(str);
     if (pointer && ((arg->pre && TEST(DRSYS_PARAM_IN, arg->mode)) ||
-                    (!arg->pre && TEST(DRSYS_PARAM_OUT, arg->mode)))) {
+        (!arg->pre && TEST(DRSYS_PARAM_OUT, arg->mode)))) {
         ptr_uint_t deref = 0;
         ASSERT(arg->size <= sizeof(deref), "too-big simple type");
         /* We assume little-endian */
-        if (dr_safe_read((void *)arg->value, arg->size, &deref, NULL))
-            dr_fprintf(outf, (leading_zeroes ? " => " PFX : " => " PIFX), deref);
+        if (dr_safe_read((void *)arg->value, arg->size, &deref, NULL)) {
+            char str[128];
+            if (leading_zeroes) {
+                sprintf(str, PFX, deref);
+                output.append(" => 0x");
+                output.append(str);
+            }
+            else {
+                sprintf(str, PIFX, deref);
+                output.append(" => ");
+                output.append(str);
+            }
+        }
     }
 }
 
 static void
-print_string(void *drcontext, void *pointer_str, bool is_wide)
+print_string(void *drcontext, void *pointer_str, bool is_wide, std::string &output)
 {
     if (pointer_str == NULL)
-        dr_fprintf(outf, "<null>");
+        output.append("<null>");
     else {
         DR_TRY_EXCEPT(drcontext, {
-            dr_fprintf(outf, is_wide ? "%S" : "%s", pointer_str);
-        }, {
-            dr_fprintf(outf, "<invalid memory>");
-        });
+            // dr_fprintf(outf, is_wide ? "%S" : "%s", pointer_str);
+            char str[256];
+        sprintf(str, PFX, pointer_str);
+        output.append("0x");
+        output.append(str);
+            }, {
+                output.append("<invalid memory>");
+            });
     }
 }
 
 static void
-print_arg(void *drcontext, drltrace_arg_t *arg)
+print_arg(void *drcontext, drltrace_arg_t *arg, std::string &output)
 {
     if (arg->pre && (TEST(DRSYS_PARAM_OUT, arg->mode) && !TEST(DRSYS_PARAM_IN, arg->mode)))
         return;
-    dr_fprintf(outf, "%s%d: ", (op_grepable.get_value() ? " {" : "\n    arg "), arg->ordinal);
+    output.append(op_grepable.get_value() ? " {" : "\n    arg ");
+    output.append(std::to_string(arg->ordinal));
+    output.append(": ");
+
     switch (arg->type) {
-    case DRSYS_TYPE_VOID:         print_simple_value(arg, true); break;
-    case DRSYS_TYPE_POINTER:      print_simple_value(arg, true); break;
-    case DRSYS_TYPE_BOOL:         print_simple_value(arg, false); break;
-    case DRSYS_TYPE_INT:          print_simple_value(arg, false); break;
-    case DRSYS_TYPE_SIGNED_INT:   print_simple_value(arg, false); break;
-    case DRSYS_TYPE_UNSIGNED_INT: print_simple_value(arg, false); break;
-    case DRSYS_TYPE_HANDLE:       print_simple_value(arg, false); break;
-    case DRSYS_TYPE_NTSTATUS:     print_simple_value(arg, false); break;
-    case DRSYS_TYPE_ATOM:         print_simple_value(arg, false); break;
-#ifdef WINDOWS
-    case DRSYS_TYPE_LCID:         print_simple_value(arg, false); break;
-    case DRSYS_TYPE_LPARAM:       print_simple_value(arg, false); break;
-    case DRSYS_TYPE_SIZE_T:       print_simple_value(arg, false); break;
-    case DRSYS_TYPE_HMODULE:      print_simple_value(arg, false); break;
-#endif
+    case DRSYS_TYPE_VOID:         print_simple_value(arg, true, output); break;
+    case DRSYS_TYPE_POINTER:      print_simple_value(arg, true, output); break;
+    case DRSYS_TYPE_BOOL:         print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_INT:          print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_SIGNED_INT:   print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_UNSIGNED_INT: print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_HANDLE:       print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_NTSTATUS:     print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_ATOM:         print_simple_value(arg, false, output); break;
+        #ifdef WINDOWS
+    case DRSYS_TYPE_LCID:         print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_LPARAM:       print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_SIZE_T:       print_simple_value(arg, false, output); break;
+    case DRSYS_TYPE_HMODULE:      print_simple_value(arg, false, output); break;
+        #endif
     case DRSYS_TYPE_CSTRING:
-        print_string(drcontext, (void *)arg->value, false);
+        print_string(drcontext, (void *)arg->value, false, output);
         break;
     case DRSYS_TYPE_CWSTRING:
-        print_string(drcontext, (void *)arg->value, true);
+        print_string(drcontext, (void *)arg->value, true, output);
         break;
     default: {
         if (arg->value == 0)
-            dr_fprintf(outf, "<null>");
-        else
-            dr_fprintf(outf, PFX, arg->value);
+            output.append("<null>");
+        else {
+            char str[128];
+            sprintf(str, PFX, arg->value);
+            output.append("0x");
+            output.append(str);
+        }
     }
     }
+    char str[128];
+    sprintf(str, PFX, arg->size);
 
-    dr_fprintf(outf, " (%s%s%stype=%s%s, size=" PIFX ")",
-              (arg->arg_name == NULL) ? "" : "name=",
-              (arg->arg_name == NULL) ? "" : arg->arg_name,
-              (arg->arg_name == NULL) ? "" : ", ",
-              (arg->type_name == NULL) ? "\"\"" : arg->type_name,
-              (arg->type_name == NULL ||
-              TESTANY(DRSYS_PARAM_INLINED|DRSYS_PARAM_RETVAL, arg->mode)) ? "" : "*",
-              arg->size);
+    output.append("(");
+    output.append((arg->arg_name == NULL) ? "" : "name=");
+    output.append((arg->arg_name == NULL) ? "" : arg->arg_name);
+    output.append((arg->arg_name == NULL) ? "" : ", ");
+    output.append("type=");
+    output.append((arg->type_name == NULL) ? "\"\"" : arg->type_name);
+    output.append((arg->type_name == NULL ||
+        TESTANY(DRSYS_PARAM_INLINED|DRSYS_PARAM_RETVAL, arg->mode)) ? "" : "*");
+    output.append(", size=0x");
+    output.append(str);
+    output.append(")");
 
     if (op_grepable.get_value())
-        dr_fprintf(outf, "}");
+        output.append("}");
 }
 
 static bool
-drlib_iter_arg_cb(drltrace_arg_t *arg, void *wrapcxt)
+drlib_iter_arg_cb(drltrace_arg_t *arg, void *wrapcxt, std::string &output)
 {
     if (arg->ordinal == -1)
         return true;
@@ -167,69 +196,74 @@ drlib_iter_arg_cb(drltrace_arg_t *arg, void *wrapcxt)
 
     arg->value = (ptr_uint_t)drwrap_get_arg(wrapcxt, arg->ordinal);
 
-    print_arg(drwrap_get_drcontext(wrapcxt), arg);
+    print_arg(drwrap_get_drcontext(wrapcxt), arg, output);
     return true; /* keep going */
 }
 
 static void
-print_args_unknown_call(app_pc func, void *wrapcxt)
+print_args_unknown_call(app_pc func, void *wrapcxt, std::string &output)
 {
     uint i;
     void *drcontext = drwrap_get_drcontext(wrapcxt);
     char *prefix = "\n    arg ";
     char *suffix = "";
     if (op_grepable.get_value()) {
-      prefix = " {";
-      suffix = "}";
+        prefix = " {";
+        suffix = "}";
     }
     DR_TRY_EXCEPT(drcontext, {
         for (i = 0; i < op_unknown_args.get_value(); i++) {
-            dr_fprintf(outf, "%s%d: " PFX, prefix, i,
-                       drwrap_get_arg(wrapcxt, i));
+            output.append(prefix);
+            output.append(std::to_string(i));
+            output.append(": ");
+            char str[128];
+            sprintf(str, PFX, drwrap_get_arg(wrapcxt, i));
+            output.append("0x");
+            output.append(str);
             if (*suffix != '\0')
-                dr_fprintf(outf, suffix);
+                output.append(suffix);
         }
-    }, {
-        dr_fprintf(outf, "<invalid memory>");
+        }, {
+            output.append("<invalid memory>");
         /* Just keep going */
-    });
+        });
     /* all args have been sucessfully printed */
-    dr_fprintf(outf, op_print_ret_addr.get_value() ? "\n   ": "");
+    output.append(op_print_ret_addr.get_value() ? "\n   ": "");
 }
 
 static bool
-print_libcall_args(std::vector<drltrace_arg_t*> *args_vec, void *wrapcxt)
+print_libcall_args(std::vector<drltrace_arg_t*> *args_vec, void *wrapcxt, std::string &output)
 {
     if (args_vec == NULL || args_vec->size() <= 0)
         return false;
 
     std::vector<drltrace_arg_t*>::iterator it;
     for (it = args_vec->begin(); it != args_vec->end(); ++it) {
-        if (!drlib_iter_arg_cb(*it, wrapcxt))
+        if (!drlib_iter_arg_cb(*it, wrapcxt, output))
             break;
     }
     return true;
 }
 
 static void
-print_symbolic_args(const char *name, void *wrapcxt, app_pc func)
+print_symbolic_args(const char *name, void *wrapcxt, app_pc func, std::string &output)
 {
     std::vector<drltrace_arg_t *> *args_vec;
 
     if (op_max_args.get_value() == 0)
         return;
 
-	if (op_use_config.get_value()) {
-		/* looking for libcall in libcalls hashtable */
-		args_vec = libcalls_search(name);
-		if (print_libcall_args(args_vec, wrapcxt)) {
-			dr_fprintf(outf, op_print_ret_addr.get_value() ? "\n   " : "");
-			return; /* we found libcall and sucessfully printed all arguments */
-		}
-	}
+    if (op_use_config.get_value()) {
+        /* looking for libcall in libcalls hashtable */
+        args_vec = libcalls_search(name);
+        if (print_libcall_args(args_vec, wrapcxt, output)) {
+            output.append(op_print_ret_addr.get_value() ? "\n   " : "");
+            return; /* we found libcall and sucessfully printed all arguments */
+        }
+    }
     /* use standard type-blind scheme */
     if (op_unknown_args.get_value() > 0)
-        print_args_unknown_call(func, wrapcxt);
+        print_args_unknown_call(func, wrapcxt, output);
 }
 
 /****************************************************************************
@@ -239,7 +273,7 @@ print_symbolic_args(const char *name, void *wrapcxt, app_pc func)
 static void
 lib_entry(void *wrapcxt, INOUT void **user_data)
 {
-    const char *name = (const char *) *user_data;
+    const char *name = (const char *)*user_data;
     const char *modname = NULL;
     app_pc func = drwrap_get_func(wrapcxt);
     module_data_t *mod;
@@ -255,9 +289,9 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
         app_pc retaddr =  NULL;
         DR_TRY_EXCEPT(drcontext, {
             retaddr = drwrap_get_retaddr(wrapcxt);
-        }, { /* EXCEPT */
-            retaddr = NULL;
-        });
+            }, { /* EXCEPT */
+                retaddr = NULL;
+            });
         if (retaddr != NULL) {
             mod = dr_lookup_module(retaddr);
             if (mod != NULL) {
@@ -266,7 +300,8 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
                 if (!from_exe)
                     return;
             }
-        } else {
+        }
+        else {
             /* Nearly all of these cases should be things like KiUserCallbackDispatcher
              * or other abnormal transitions.
              * If the user really wants to see everything they can not pass
@@ -289,9 +324,9 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
 
     /* Temporary workaround for VC2013, which doesn't have snprintf().
      * apparently, this was added in later releases... */
-#ifdef WINDOWS
-#define snprintf _snprintf
-#endif
+    #ifdef WINDOWS
+    #define snprintf _snprintf
+    #endif
     unsigned int module_name_len = (unsigned int)snprintf(module_name, \
         sizeof(module_name) - 1, "%s%s%s", modname == NULL ? "" : modname, \
         modname == NULL ? "" : "!", name);
@@ -300,78 +335,94 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
     bool allowed = false;
     bool tested = false;  /* True only if any white/blacklist testing below is done. */
     for (unsigned int i = 0; (allowed == false) && (i < filter_function_whitelist_len); i++) {
-      tested = true;
+        tested = true;
 
-      /* If the whitelist entry contains a wildcard, then compare only the shortest
-       * part of either string. */
-      unsigned int module_name_len_compare;
-      if (filter_function_whitelist[i].is_wildcard)
-        module_name_len_compare = MIN(module_name_len, \
-          filter_function_whitelist[i].func_name_len);
-      else
-        module_name_len_compare = module_name_len;
+        /* If the whitelist entry contains a wildcard, then compare only the shortest
+         * part of either string. */
+        unsigned int module_name_len_compare;
+        if (filter_function_whitelist[i].is_wildcard)
+            module_name_len_compare = MIN(module_name_len, \
+                filter_function_whitelist[i].func_name_len);
+        else
+            module_name_len_compare = module_name_len;
 
-      if (fast_strcmp(module_name, module_name_len_compare, \
-          filter_function_whitelist[i].func_name, \
-          filter_function_whitelist[i].func_name_len) == 0) {
-        allowed = true;
-      }
+        if (fast_strcmp(module_name, module_name_len_compare, \
+            filter_function_whitelist[i].func_name, \
+            filter_function_whitelist[i].func_name_len) == 0) {
+            allowed = true;
+        }
     }
 
     /* Check the blacklist if it was specified instead of a whitelist. */
     if (!allowed && filter_function_blacklist_len > 0) {
-      allowed = true;
-      for (unsigned int i = 0; allowed && (i < filter_function_blacklist_len); i++) {
-        tested = true;
+        allowed = true;
+        for (unsigned int i = 0; allowed && (i < filter_function_blacklist_len); i++) {
+            tested = true;
 
-	/* If the blacklist entry contains a wildcard, then compare only the shortest
-	 * part of either string. */
-        unsigned int module_name_len_compare;
-        if (filter_function_blacklist[i].is_wildcard)
-          module_name_len_compare = MIN(module_name_len, \
-            filter_function_blacklist[i].func_name_len);
-        else
-          module_name_len_compare = module_name_len;
+            /* If the blacklist entry contains a wildcard, then compare only the shortest
+             * part of either string. */
+            unsigned int module_name_len_compare;
+            if (filter_function_blacklist[i].is_wildcard)
+                module_name_len_compare = MIN(module_name_len, \
+                    filter_function_blacklist[i].func_name_len);
+            else
+                module_name_len_compare = module_name_len;
 
-        if (fast_strcmp(module_name, module_name_len_compare, \
-            filter_function_blacklist[i].func_name, \
-            filter_function_blacklist[i].func_name_len) == 0) {
-          allowed = false;
+            if (fast_strcmp(module_name, module_name_len_compare, \
+                filter_function_blacklist[i].func_name, \
+                filter_function_blacklist[i].func_name_len) == 0) {
+                allowed = false;
+            }
         }
-      }
     }
 
     /* If whitelist/blacklist testing was performed, and it was determined
      * this function is not to be logged... */
     if (tested && !allowed)
-      return;
+        return;
+
+    std::string output = "";
 
     tid = dr_get_thread_id(drcontext);
-    if (tid != INVALID_THREAD_ID)
-        dr_fprintf(outf, "~~%d~~ ", tid);
+    if (tid != INVALID_THREAD_ID) {
+        output.append("~~");
+        output.append(std::to_string(tid));
+        output.append("~~ ");
+    }
     else
-        dr_fprintf(outf, "~~Dr.L~~ ");
-    dr_fprintf(outf, module_name);
+        output.append("~~Dr.L~~ ");
+
+    output.append(module_name);
 
     /* XXX: We employ two schemes of arguments printing.  We are looking for prototypes
      * in config file specified by user to get symbolic representation of arguments
      * for known library calls. For the rest of library calls.  If there is no info
      * we employ type-blindprinting and use -num_unknown_args to get a count of arguments
-	 * to print.
+   * to print.
      */
-    print_symbolic_args(name, wrapcxt, func);
+    print_symbolic_args(name, wrapcxt, func, output);
 
     if (op_print_ret_addr.get_value()) {
         ret_addr = drwrap_get_retaddr(wrapcxt);
         res = drmodtrack_lookup(drcontext, ret_addr, &mod_id, &mod_start);
         if (res == DRCOVLIB_SUCCESS) {
-            dr_fprintf(outf,
-                       op_print_ret_addr.get_value() ?
-                       " and return to module id:%d, offset:" PIFX : "",
-                       mod_id, ret_addr - mod_start);
+            if (op_print_ret_addr.get_value()) {
+                output.append(" and return to module id:");
+                output.append(std::to_string(mod_id));
+                output.append(", offset:");
+                char str[128];
+                sprintf(str, PIFX, ret_addr - mod_start);
+                output.append(str);
+            }
         }
     }
-    dr_fprintf(outf, "\n");
+
+    output.append("\n");
+    char * output_array;
+    output_array = (char*)calloc(output.length() + 1, sizeof(char));
+    strcpy(output_array, output.c_str());
+    dr_fprintf(outf, output_array);
+    free(output_array);
     if (mod != NULL)
         dr_free_module_data(mod);
 }
@@ -386,30 +437,31 @@ iterate_exports(const module_data_t *info, bool add)
         app_pc func = NULL;
         if (sym->is_code)
             func = sym->addr;
-#ifdef LINUX
+        #ifdef LINUX
         else if (sym->is_indirect_code) {
             /* Invoke the export to get the real entry: */
-            app_pc (*indir)(void) = (app_pc (*)(void)) cast_to_func(sym->addr);
+            app_pc(*indir)(void) = (app_pc(*)(void)) cast_to_func(sym->addr);
             void *drcontext = dr_get_current_drcontext();
             DR_TRY_EXCEPT(drcontext, {
                 func = (*indir)();
-            }, { /* EXCEPT */
-                func = NULL;
-            });
+                }, { /* EXCEPT */
+                    func = NULL;
+                });
             VNOTIFY(2, "export %s indirected from " PFX " to " PFX NL,
-                   sym->name, sym->addr, func);
+                sym->name, sym->addr, func);
         }
-#endif
+        #endif
         if (op_ignore_underscore.get_value() && strstr(sym->name, "_") == sym->name)
             func = NULL;
         if (func != NULL) {
             if (add) {
                 IF_DEBUG(bool ok =)
-                    drwrap_wrap_ex(func, lib_entry, NULL, (void *) sym->name, 0);
+                    drwrap_wrap_ex(func, lib_entry, NULL, (void *)sym->name, 0);
                 ASSERT(ok, "wrap request failed");
                 VNOTIFY(2, "wrapping export %s!%s @" PFX NL,
-                       dr_module_preferred_name(info), sym->name, func);
-            } else {
+                    dr_module_preferred_name(info), sym->name, func);
+            }
+            else {
                 IF_DEBUG(bool ok =)
                     drwrap_unwrap(func, lib_entry, NULL);
                 ASSERT(ok, "unwrap request failed");
@@ -422,35 +474,37 @@ iterate_exports(const module_data_t *info, bool add)
 static bool
 library_matches_filter(const module_data_t *info)
 {
-  if (!filter_module_whitelist.empty()) {
-    const char *libname = dr_module_preferred_name(info);
-    if (libname == NULL)
-      return false;
+    if (!filter_module_whitelist.empty()) {
+        const char *libname = dr_module_preferred_name(info);
+        if (libname == NULL)
+            return false;
 
-    for (std::vector<std::string>::const_iterator iter = \
-        filter_module_whitelist.begin(); iter != filter_module_whitelist.end(); \
-        iter++) {
+        for (std::vector<std::string>::const_iterator iter = \
+            filter_module_whitelist.begin(); iter != filter_module_whitelist.end(); \
+            iter++) {
 
-      if (strcmp(libname, iter->c_str()) == 0)
-	return true;
+            if (strcmp(libname, iter->c_str()) == 0)
+                return true;
+        }
+
+        return false;
     }
+    else if (!filter_module_blacklist.empty()) {
+        const char *libname = dr_module_preferred_name(info);
+        if (libname == NULL)
+            return true;
 
-    return false;
-  } else if (!filter_module_blacklist.empty()) {
-    const char *libname = dr_module_preferred_name(info);
-    if (libname == NULL)
-      return true;
+        for (std::vector<std::string>::const_iterator iter = \
+            filter_module_blacklist.begin(); iter != filter_module_blacklist.end(); \
+            iter++) {
+            if (strcmp(libname, iter->c_str()) == 0)
+                return false;
+        }
 
-    for (std::vector<std::string>::const_iterator iter = \
-        filter_module_blacklist.begin(); iter != filter_module_blacklist.end(); \
-        iter++) {
-      if (strcmp(libname, iter->c_str()) == 0)
-	return false;
+        return true;
     }
-
-    return true;
-  } else
-    return true;
+    else
+        return true;
 }
 
 static void
@@ -479,13 +533,13 @@ open_log_file(void)
         outf = STDERR;
     else {
         outf = drx_open_unique_appid_file(op_logdir.get_value().c_str(),
-                                          dr_get_process_id(),
-                                          "drltrace", "log",
-#ifndef WINDOWS
-                                          DR_FILE_CLOSE_ON_FORK |
-#endif
-                                          DR_FILE_ALLOW_LARGE,
-                                          buf, BUFFER_SIZE_ELEMENTS(buf));
+            dr_get_process_id(),
+            "drltrace", "log",
+            #ifndef WINDOWS
+            DR_FILE_CLOSE_ON_FORK |
+            #endif
+            DR_FILE_ALLOW_LARGE,
+            buf, BUFFER_SIZE_ELEMENTS(buf));
         ASSERT(outf != INVALID_FILE, "failed to open log file");
         VNOTIFY(0, "drltrace log file is %s" NL, buf);
 
@@ -495,33 +549,33 @@ open_log_file(void)
 /* Frees a wblist array. */
 static void
 free_wblist_array(wb_list **wbl, unsigned int wb_list_len) {
-  if ((wbl == NULL) || (*wbl == NULL) || (wb_list_len == 0))
-    return;
+    if ((wbl == NULL) || (*wbl == NULL) || (wb_list_len == 0))
+        return;
 
-  /* Loop through all entries and free the function name, since it was
-   * created with strdup().  Set it (and the length) to zero for good
-   * measure. */
-  for (unsigned int i = 0; i < wb_list_len; i++) {
-    wb_list *l = *wbl;
-    free(l[i].func_name);  l[i].func_name = NULL;
-    l[i].func_name_len = 0;
-  }
+    /* Loop through all entries and free the function name, since it was
+     * created with strdup().  Set it (and the length) to zero for good
+     * measure. */
+    for (unsigned int i = 0; i < wb_list_len; i++) {
+        wb_list *l = *wbl;
+        free(l[i].func_name);  l[i].func_name = NULL;
+        l[i].func_name_len = 0;
+    }
 
-  /* Now free the array itself. */
-  free(*wbl);  *wbl = NULL;
+    /* Now free the array itself. */
+    free(*wbl);  *wbl = NULL;
 }
 
 /* Adds a module name to the module filter. */
 void
 add_module_filter(std::vector<std::string> &module_wbl, const char *module_name) {
 
-  /* If the module name is already in the filter, ignore. */
-  for (std::vector<std::string>::const_iterator iter = module_wbl.begin(); iter != module_wbl.end(); iter++) {
-    if (strcmp(module_name, iter->c_str()) == 0)
-      return;
-  }
+    /* If the module name is already in the filter, ignore. */
+    for (std::vector<std::string>::const_iterator iter = module_wbl.begin(); iter != module_wbl.end(); iter++) {
+        if (strcmp(module_name, iter->c_str()) == 0)
+            return;
+    }
 
-  module_wbl.push_back(module_name);
+    module_wbl.push_back(module_name);
 }
 
 /* Convert a vector to an array of wb_list structs.  This may be faster
@@ -529,125 +583,127 @@ add_module_filter(std::vector<std::string> &module_wbl, const char *module_name)
 static void
 parse_filter(std::vector<std::string> &v_in, bool is_whitelist, std::vector<std::string> &module_wbl, wb_list **func_wbl, unsigned int *func_wbl_len) {
 
-  /* First look for entries that don't have a '!'; these are module names that
-   * need to be filtered at the module-level. */
-  for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
-       iter != v_in.end(); iter++) {
-    if (iter->find('!') == std::string::npos)
-      add_module_filter(module_wbl, iter->c_str());
-  }
-
-  /* Allocate the array of wb_list structs. */
-  unsigned int v_in_len = v_in.size();
-  *func_wbl = (wb_list *)calloc(v_in_len, sizeof(wb_list));
-  if (*func_wbl == NULL) {
-    fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
-    exit(-1);
-  }
-
-  /* For every entry in the vector, strdup() the function name and add
-   * it to the array. */
-  unsigned j = 0;
-  for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
-       (iter != v_in.end()) && (j < v_in_len); iter++, j++) {
-
-    unsigned int is_wildcard = 0;
-    char *s = strdup(iter->c_str());
-    if (s == NULL) {
-      fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
-      exit(-1);
+    /* First look for entries that don't have a '!'; these are module names that
+     * need to be filtered at the module-level. */
+    for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
+        iter != v_in.end(); iter++) {
+        if (iter->find('!') == std::string::npos)
+            add_module_filter(module_wbl, iter->c_str());
     }
 
-    /* If the function name ends with a '*', then it is a wildcard prefix.  Set the
-     * wildcard flag and cut off the trailing '*'. */
-    if (s[strlen(s) - 1] == '*') {
-      s[strlen(s) - 1] = '\0';
-      is_wildcard = 1;
-
-    /* If a module name was provided without a corresponding function, then this is a
-     * wildcard module.  These, too, must be added to the function-level filter in
-     * order for whitelisted functions to be allowed through. */
-    } else if (strchr(s, '!') == NULL)
-      is_wildcard = 1;
-
-    /* If we're parsing the whitelist filter, ensure that the module for this function
-     * is in the module whitelist as well, otherwise the function-level filtering will
-     * never trigger. */
-    if (is_whitelist) {
-      char *module_name = strdup(s);
-      char *bang_pos = strchr(module_name, '!');
-      if (bang_pos != NULL) {
-	*bang_pos = '\0';
-	add_module_filter(module_wbl, module_name);
-      }
-      free(module_name);  module_name = NULL;
+    /* Allocate the array of wb_list structs. */
+    unsigned int v_in_len = v_in.size();
+    *func_wbl = (wb_list *)calloc(v_in_len, sizeof(wb_list));
+    if (*func_wbl == NULL) {
+        fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
+        exit(-1);
     }
 
-    wb_list *l = *func_wbl;
-    l[j].func_name = s;
-    l[j].is_wildcard = is_wildcard;
+    /* For every entry in the vector, strdup() the function name and add
+     * it to the array. */
+    unsigned j = 0;
+    for (std::vector<std::string>::const_iterator iter = v_in.begin(); \
+        (iter != v_in.end()) && (j < v_in_len); iter++, j++) {
 
-    /* We store the function name length too, so we don't repeatedly
-     * call strlen() on an unchanging string in the critical region. */
-    l[j].func_name_len = strlen(s);
-  }
+        unsigned int is_wildcard = 0;
+        char *s = strdup(iter->c_str());
+        if (s == NULL) {
+            fprintf(stderr, "Failed to allocate whitelist/blacklist array.\n");
+            exit(-1);
+        }
 
-  *func_wbl_len = v_in_len;
+        /* If the function name ends with a '*', then it is a wildcard prefix.  Set the
+         * wildcard flag and cut off the trailing '*'. */
+        if (s[strlen(s) - 1] == '*') {
+            s[strlen(s) - 1] = '\0';
+            is_wildcard = 1;
+
+            /* If a module name was provided without a corresponding function, then this is a
+             * wildcard module.  These, too, must be added to the function-level filter in
+             * order for whitelisted functions to be allowed through. */
+        }
+        else if (strchr(s, '!') == NULL)
+            is_wildcard = 1;
+
+        /* If we're parsing the whitelist filter, ensure that the module for this function
+         * is in the module whitelist as well, otherwise the function-level filtering will
+         * never trigger. */
+        if (is_whitelist) {
+            char *module_name = strdup(s);
+            char *bang_pos = strchr(module_name, '!');
+            if (bang_pos != NULL) {
+                *bang_pos = '\0';
+                add_module_filter(module_wbl, module_name);
+            }
+            free(module_name);  module_name = NULL;
+        }
+
+        wb_list *l = *func_wbl;
+        l[j].func_name = s;
+        l[j].is_wildcard = is_wildcard;
+
+        /* We store the function name length too, so we don't repeatedly
+         * call strlen() on an unchanging string in the critical region. */
+        l[j].func_name_len = strlen(s);
+    }
+
+    *func_wbl_len = v_in_len;
 }
 
 /* Parse the whitelist/blacklist entries in the filter file. */
 static void
 parse_filter_file(void)
 {
-  if (op_filter_file.get_value().empty())
-    return;
+    if (op_filter_file.get_value().empty())
+        return;
 
-  std::vector<std::string> temp_whitelist;
-  std::vector<std::string> temp_blacklist;
+    std::vector<std::string> temp_whitelist;
+    std::vector<std::string> temp_blacklist;
 
-  std::ifstream filter_file(op_filter_file.get_value().c_str());
+    std::ifstream filter_file(op_filter_file.get_value().c_str());
 
-  /* Loop through every line in the filter file. */
-  std::string line;
-  bool mode_whitelist = false, mode_blacklist = false;
-  while (std::getline(filter_file, line)) {
+    /* Loop through every line in the filter file. */
+    std::string line;
+    bool mode_whitelist = false, mode_blacklist = false;
+    while (std::getline(filter_file, line)) {
 
-    /* Skip empty lines and comments. */
-    if (line.empty() || (line.find("#") == 0))
-      continue;
+        /* Skip empty lines and comments. */
+        if (line.empty() || (line.find("#") == 0))
+            continue;
 
-    /* When we find a whitelist header, add subsequent lines to the whitelist.
-    /* Otherwise, when we find a blacklist header, add subsequent lines to the
-    /* blacklist. */
-    if (line == std::string("[whitelist]")) {
-      mode_whitelist = true;
-      mode_blacklist = false;
-      continue;
-    } else if (line == std::string("[blacklist]")) {
-      mode_whitelist = false;
-      mode_blacklist = true;
-      continue;
+        /* When we find a whitelist header, add subsequent lines to the whitelist.
+        /* Otherwise, when we find a blacklist header, add subsequent lines to the
+        /* blacklist. */
+        if (line == std::string("[whitelist]")) {
+            mode_whitelist = true;
+            mode_blacklist = false;
+            continue;
+        }
+        else if (line == std::string("[blacklist]")) {
+            mode_whitelist = false;
+            mode_blacklist = true;
+            continue;
+        }
+
+        if (mode_whitelist)
+            temp_whitelist.push_back(line);
+        else if (mode_blacklist)
+            temp_blacklist.push_back(line);
     }
 
-    if (mode_whitelist)
-      temp_whitelist.push_back(line);
-    else if (mode_blacklist)
-      temp_blacklist.push_back(line);
-  }
+    /* If both a whitelist and a blacklist was specified, the blacklist is
+     * ignored. */
+    if (!temp_whitelist.empty() && !temp_blacklist.empty())
+        temp_blacklist.clear();
 
-  /* If both a whitelist and a blacklist was specified, the blacklist is
-   * ignored. */
-  if (!temp_whitelist.empty() && !temp_blacklist.empty())
-    temp_blacklist.clear();
+    /* Convert the vectors to an array of wb_list structs.  This is
+     * possibly faster to process in the critical region later. */
+    if (!temp_whitelist.empty())
+        parse_filter(temp_whitelist, true, filter_module_whitelist, &filter_function_whitelist, &filter_function_whitelist_len);
+    else if (!temp_blacklist.empty())
+        parse_filter(temp_blacklist, false, filter_module_blacklist, &filter_function_blacklist, &filter_function_blacklist_len);
 
-  /* Convert the vectors to an array of wb_list structs.  This is
-   * possibly faster to process in the critical region later. */
-  if (!temp_whitelist.empty())
-    parse_filter(temp_whitelist, true, filter_module_whitelist, &filter_function_whitelist, &filter_function_whitelist_len);
-  else if (!temp_blacklist.empty())
-    parse_filter(temp_blacklist, false, filter_module_blacklist, &filter_function_blacklist, &filter_function_blacklist_len);
-
-  filter_file.close();
+    filter_file.close();
 }
 
 #ifndef WINDOWS
@@ -687,23 +743,23 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     module_data_t *exe;
     IF_DEBUG(bool ok;)
 
-    dr_set_client_name("Dr. LTrace", "???");
+        dr_set_client_name("Dr. LTrace", "???");
 
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv,
-                                       NULL, NULL))
+        NULL, NULL))
         ASSERT(false, "unable to parse options specified for drltracelib");
 
-    IF_DEBUG(ok = )
+    IF_DEBUG(ok =)
         drmgr_init();
     ASSERT(ok, "drmgr failed to initialize");
-    IF_DEBUG(ok = )
+    IF_DEBUG(ok =)
         drwrap_init();
     ASSERT(ok, "drwrap failed to initialize");
-    IF_DEBUG(ok = )
+    IF_DEBUG(ok =)
         drx_init();
     ASSERT(ok, "drx failed to initialize");
     if (op_print_ret_addr.get_value()) {
-        IF_DEBUG(ok = )
+        IF_DEBUG(ok =)
             drmodtrack_init();
         ASSERT(ok == DRCOVLIB_SUCCESS, "drmodtrack failed to initialize");
     }
@@ -719,18 +775,18 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
      * we don't care about the app context.
      */
     drwrap_set_global_flags((drwrap_global_flags_t)
-                            (DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));
+        (DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));
 
     dr_register_exit_event(event_exit);
-#ifdef UNIX
+    #ifdef UNIX
     dr_register_fork_init_event(event_fork);
-#endif
+    #endif
     drmgr_register_module_load_event(event_module_load);
     drmgr_register_module_unload_event(event_module_unload);
 
-#ifdef WINDOWS
+    #ifdef WINDOWS
     dr_enable_console_printing();
-#endif
+    #endif
     if (op_max_args.get_value() > 0)
         parse_config();
 


### PR DESCRIPTION
The API calls were not printed in the right order.
This commit introduces a string that we fill for each API call so we can return all the information at once.

Outputing arguments in wide strings format still needs to be implemented.
For now, only the address is printed.

---
As you can see in the picture bellow, I had problems in the way the tool prints logs.
I wrote something to correct it and it seems to work for the API calls' names.
As I do not need the information about the arguments, I did not test whether or not they are well printed.  
I'm not used to code in C++ so this commit may not follow the good practices. I thought you might be interested anyway.

![error](https://user-images.githubusercontent.com/6296846/89924720-b7ce0900-dc02-11ea-8b14-3da373ce32e2.PNG)
